### PR TITLE
168 me   modificar imagenes

### DIFF
--- a/src/decorators/role.decorator.ts
+++ b/src/decorators/role.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../Enum/roles.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/guard/property-ownership.guard.ts
+++ b/src/guard/property-ownership.guard.ts
@@ -1,0 +1,43 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Request } from 'express';
+import { ImagesService } from '../modules/images/images.service'; 
+import { Role } from '../Enum/roles.enum';
+
+@Injectable()
+export class PropertyOwnershipGuard implements CanActivate {
+  constructor(private readonly imagesService: ImagesService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request & { user: { id: string; roles: Role[] } }>();
+    const userId = request.user.id;
+    const imageId = request.params.id;
+
+    if (request.user.roles.includes(Role.Admin)) {
+      return true;
+    }
+
+    const image = await this.imagesService.findOneWithPropertyAndOwner(imageId);
+
+    if (!image) {
+      throw new NotFoundException(`Imagen con ID "${imageId}" no encontrada.`);
+    }
+
+    if (!image.property) {//por si hay una imagen huerfana :)
+      throw new ForbiddenException('La imagen no está asociada a una propiedad válida.');
+    }
+
+    if (!image.property.agency) { //por si sigue huerfano pero sin agency
+      throw new ForbiddenException('La propiedad de la imagen no está asociada a una agencia válida.');
+    }
+
+    if (!image.property.agency.user) {
+        throw new ForbiddenException('La agencia de la propiedad no tiene un usuario propietario definido.');
+    }
+
+    if (image.property.agency.user.id === userId) {
+      return true;
+    }
+
+    throw new ForbiddenException('No tienes permisos para realizar esta acción sobre esta imagen.');
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,30 +2,35 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as cookieParser from 'cookie-parser';
-import {loggerGlobal} from './middlewares/logger-global/logger-global.middleware'
+import { loggerGlobal } from './middlewares/logger-global/logger-global.middleware';
 import * as express from 'express';
 async function bootstrap() {
-
   const app = await NestFactory.create(AppModule);
   app.enableCors({
-    origin: ['http://localhost:3000', 'http://localhost:3001', 'http://tkdsystem.ddns.net:3001', 'http://tkdsystem.ddns.net:3000', "kasapp.serveminecraft.net:3000", "kasapp.serveminecraft.net:3001"],
+    origin: [
+      'http://localhost:3000',
+      'http://localhost:3001',
+      'http://tkdsystem.ddns.net:3001',
+      'http://tkdsystem.ddns.net:3000',
+      'kasapp.serveminecraft.net:3000',
+      'kasapp.serveminecraft.net:3001',
+    ],
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     preflightContinue: false,
     optionsSuccessStatus: 204,
-    credentials: true
-  })
+    credentials: true,
+  });
   app.use('/stripe/webhook', express.raw({ type: 'application/json' }));
 
   const swaggerConfig = new DocumentBuilder()
-  .setTitle('Kasapp')
-  .setVersion('1.0')
-  .setDescription(
-  "Esta es la documentacionde nuestra app Kasapp")
-  .build();
+    .setTitle('Kasapp')
+    .setVersion('1.0')
+    .setDescription('Esta es la documentacionde nuestra app Kasapp')
+    .addBearerAuth()
+    .build();
   app.use(cookieParser());
   const document = SwaggerModule.createDocument(app, swaggerConfig);
   SwaggerModule.setup('api', app, document);
-  
 
   app.use(loggerGlobal);
 

--- a/src/modules/agency/agency.controller.ts
+++ b/src/modules/agency/agency.controller.ts
@@ -1,41 +1,102 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete} from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+} from '@nestjs/common';
 import { AgencyService } from './agency.service';
 import { CreateAgencyDto } from './agency.dto';
+import { AuthGuard } from '../../guard/auth.guard';
+import { AgencyGuard } from '../../guard/agency.guard';
+import { RolesGuard } from '../../guard/roles.guard';
+import { Roles } from '../../decorators/role.decorator';
+import { Role } from '../../Enum/roles.enum';
+import {
+  ApiBearerAuth,
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
 
-
+@ApiTags('agency')
+@ApiBearerAuth()
 @Controller('agency')
 export class AgencyController {
   constructor(private readonly agencyService: AgencyService) {}
 
   @Post()
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(Role.User)
+  @ApiOperation({ summary: 'Crear nueva Agency (Solo User)' })
+  @ApiResponse({
+    status: 201,
+    description: 'La Agency ha sido creada exitosamente.',
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
   create(@Body() createAgencyDto: CreateAgencyDto) {
     return this.agencyService.create(createAgencyDto);
   }
 
-  
   @Get()
+  @UseGuards(AuthGuard)
+  @ApiOperation({ summary: 'Obtener todas las agencies' })
+  @ApiResponse({ status: 200, description: 'Son todas las agencies.' })
   findAll() {
     return this.agencyService.findAll();
   }
+
   @Get('getByUser/:id')
- async getByUser(@Param('id') id: string) {
+  @UseGuards(AuthGuard, AgencyGuard)
+  @ApiOperation({ summary: 'Obtener agency por ID del usuario' })
+  @ApiResponse({
+    status: 200,
+    description: 'Es la agency para el usuario especificado.',
+  })
+  @ApiResponse({ status: 404, description: 'Usuario o agency no encontrado.' })
+  async getByUser(@Param('id') id: string) {
     const useId = parseInt(id);
-    console.log(useId)
+    console.log(useId);
     const agency = await this.agencyService.findOneByUserId(useId);
-    console.log(agency)
-    return agency
-    }
+    console.log(agency);
+    return agency;
+  }
+
   @Get(':id')
+  @ApiOperation({ summary: 'Obtener agency por ID (Public)' })
+  @ApiResponse({ status: 200, description: 'Obtuviste la agency.' })
+  @ApiResponse({ status: 404, description: 'Agency no encontrada.' })
+  @ApiBearerAuth('public')
   findOne(@Param('id') id: string) {
     return this.agencyService.findOne(id);
   }
 
   @Patch(':id')
+  @UseGuards(AuthGuard, AgencyGuard)
+  @ApiOperation({ summary: 'Actualizar agency' })
+  @ApiResponse({
+    status: 200,
+    description: 'La agency ha sido actualizada exitosamente.',
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
+  @ApiResponse({ status: 404, description: 'Agency no encontrada.' })
   update(@Param('id') id: string, @Body() updateAgencyDto: CreateAgencyDto) {
     return this.agencyService.update(id, updateAgencyDto);
   }
 
   @Delete(':id')
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(Role.User)
+  @ApiOperation({ summary: 'Eliminar agency (Solo User)' })
+  @ApiResponse({
+    status: 200,
+    description: 'La agency ha sido eliminada exitosamente.',
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
+  @ApiResponse({ status: 404, description: 'Agency no encontrada.' })
   remove(@Param('id') id: string) {
     return this.agencyService.remove(id);
   }

--- a/src/modules/agency/agency.dto.ts
+++ b/src/modules/agency/agency.dto.ts
@@ -1,11 +1,13 @@
-import { CustomizationDTO } from "src/Interface/Customization";
-import { PropertyDTO } from "src/Interface/Property";
-import { UserDTO } from "src/Interface/User";
-import { IsNotEmpty, IsString, MinLength, MaxLength } from 'class-validator';
-import { PartialType } from "@nestjs/mapped-types";
+import {
+  IsNotEmpty,
+  IsString,
+  MinLength,
+  MaxLength,
+  IsArray,
+} from 'class-validator';
+import { PartialType } from '@nestjs/mapped-types';
 
 export class CreateAgencyDto {
-
   @IsNotEmpty()
   @IsString()
   @MinLength(3)
@@ -17,21 +19,21 @@ export class CreateAgencyDto {
   description: string;
 
   @IsNotEmpty()
-  customization: CustomizationDTO;
+  customization: string;
 
   @IsNotEmpty()
-  properties: PropertyDTO[]; 
+  @IsArray()
+  @IsString({ each: true })
+  propertyIds: string[];
 
   @IsNotEmpty()
-  agentUser: UserDTO; 
+  agentUser: number;
 
   @IsNotEmpty()
   @IsString()
-  cuit_dni_m: string; 
-
+  cuit_dni_m: string;
 }
 
-
-export class UpdateAgencyDto extends PartialType(CreateAgencyDto){
+export class UpdateAgencyDto extends PartialType(CreateAgencyDto) {
   customerId?: string;
 }

--- a/src/modules/agency/agency.module.ts
+++ b/src/modules/agency/agency.module.ts
@@ -1,14 +1,21 @@
 import { Module } from '@nestjs/common';
-import { AgencyService } from './agency.service';
-import { AgencyController } from './agency.controller';
+import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Agency } from './agency.entity';
 import { UserModule } from '../user/user.module';
+import { AgencyService } from './agency.service';
+import { AgencyController } from './agency.controller';
+import { AgencyGuard } from '../../guard/agency.guard';
+import { User } from '../user/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Agency]), UserModule],
+  imports: [
+    TypeOrmModule.forFeature([Agency, User]),
+    UserModule,
+    JwtModule.register({}),
+  ],
   controllers: [AgencyController],
-  providers: [AgencyService],
-  exports:[AgencyService]
+  providers: [AgencyService, AgencyGuard],
+  exports: [AgencyService],
 })
 export class AgencyModule {}

--- a/src/modules/agency/agency.service.ts
+++ b/src/modules/agency/agency.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CreateAgencyDto, UpdateAgencyDto } from './agency.dto'
+import { CreateAgencyDto, UpdateAgencyDto } from './agency.dto';
 import { Agency } from './agency.entity';
 import { UserService } from '../user/user.service';
 
@@ -10,20 +10,29 @@ export class AgencyService {
   constructor(
     @InjectRepository(Agency)
     private agencyRepository: Repository<Agency>,
-    private readonly userService : UserService
+    private readonly userService: UserService,
   ) {}
 
   async create(createAgencyDto: CreateAgencyDto): Promise<Agency> {
+    const user = await this.userService.findOne(createAgencyDto.agentUser);
+    if (!user) {
+      throw new NotFoundException(
+        `User with ID ${createAgencyDto.agentUser} not found`,
+      );
+    }
 
-    const user = await this.userService.findOne(createAgencyDto.agentUser.id);
     const agency = new Agency();
     agency.name = createAgencyDto.name;
     agency.description = createAgencyDto.description;
     agency.document = createAgencyDto.cuit_dni_m;
-    agency.id_customization = createAgencyDto.customization.id;
-    agency.user = user; ;
+    agency.id_customization = Number(createAgencyDto.customization);
+    if (createAgencyDto.propertyIds?.length > 0) {
+      agency.id_property = Number(createAgencyDto.propertyIds[0]);
+    }
 
-    return await this.agencyRepository.save(agency);
+    agency.user = user;
+
+    return this.agencyRepository.save(agency);
   }
 
   async findAll(): Promise<Agency[]> {
@@ -39,7 +48,7 @@ export class AgencyService {
     });
 
     if (!agency) {
-      throw new NotFoundException("Agency with ID ${id} not found");
+      throw new NotFoundException('Agency with ID ${id} not found');
     }
 
     return agency;
@@ -49,43 +58,49 @@ export class AgencyService {
     const agency = await this.agencyRepository.findOne({
       where: { stripeCustomerId: customerId },
       relations: ['customization', 'properties', 'user'],
-    })
+    });
 
     if (!agency) {
-      throw new NotFoundException("Agency with ID ${id} not found");
+      throw new NotFoundException('Agency with ID ${id} not found');
     }
-    return agency 
+    return agency;
   }
   async findOneByUserId(userId: number): Promise<Agency> {
-    console.log(userId)
     const agency = await this.agencyRepository.findOne({
       where: { user: { id: userId } },
+      relations: ['customization', 'properties', 'user'],
     });
-    console.log(agency)
     if (!agency) {
-      throw new NotFoundException("Agency with ID ${id} not found");
+      throw new NotFoundException('Agency with ID ${id} not found');
     }
-    return agency
-  }
-  async updateCustomerId(agencyId: string, customerId: string): Promise<Agency> {
-    const agency = await this.findOne(agencyId);
-    agency.stripeCustomerId = customerId;
-    return await this.agencyRepository.save(agency);
+    return agency;
   }
   async update(id: string, updateAgencyDto: UpdateAgencyDto): Promise<Agency> {
     const agency = await this.findOne(id);
-    if ( !updateAgencyDto.agentUser ) throw new NotFoundException("User not found");
-    const user = await this.userService.findOne(updateAgencyDto.agentUser.id);
-    if (updateAgencyDto.name) agency.name = updateAgencyDto.name;
-    if (updateAgencyDto.description) agency.description = updateAgencyDto.description;
-    if (updateAgencyDto.cuit_dni_m) agency.document = updateAgencyDto.cuit_dni_m;
-    if (updateAgencyDto.customization) agency.id_customization = updateAgencyDto.customization.id;
-    if (updateAgencyDto.properties) agency.id_property = updateAgencyDto.properties[0]?.id;
+
     if (updateAgencyDto.agentUser) {
+      const user = await this.userService.findOne(updateAgencyDto.agentUser);
+      if (!user) {
+        throw new NotFoundException(
+          `User with ID ${updateAgencyDto.agentUser} not found`,
+        );
+      }
       agency.user = user;
     }
 
-    return await this.agencyRepository.save(agency);
+    if (updateAgencyDto.name) agency.name = updateAgencyDto.name;
+    if (updateAgencyDto.description)
+      agency.description = updateAgencyDto.description;
+    if (updateAgencyDto.cuit_dni_m)
+      agency.document = updateAgencyDto.cuit_dni_m;
+    if (updateAgencyDto.customization) {
+      agency.id_customization = Number(updateAgencyDto.customization);
+    }
+    if (updateAgencyDto.propertyIds && updateAgencyDto.propertyIds.length > 0) {
+      agency.id_property = Number(updateAgencyDto.propertyIds[0]);
+    }
+
+    return this.agencyRepository.save(agency);
   }
 
   async remove(id: string): Promise<void> {
@@ -96,5 +111,20 @@ export class AgencyService {
   async existsAgency(id: string): Promise<boolean> {
     const agency = await this.findOne(id);
     return !!agency;
+  }
+
+  async updateCustomerId(
+    agencyId: string,
+    customerId: string,
+  ): Promise<Agency> {
+    const agency = await this.agencyRepository.findOne({
+      where: { id: agencyId },
+    });
+    if (!agency) {
+      throw new NotFoundException(`Agency with ID ${agencyId} not found`);
+    }
+
+    agency.stripeCustomerId = customerId;
+    return this.agencyRepository.save(agency);
   }
 }

--- a/src/modules/images/Readme.md
+++ b/src/modules/images/Readme.md
@@ -1,0 +1,144 @@
+# 📸 Módulo de Gestión de Imágenes (`/src/modules/images`)
+
+¡Bienvenido al **centro visual** de tu plataforma inmobiliaria! Este módulo es el motor que impulsa la gestión de todas las fotografías de tus propiedades, asegurando que cada listado brille con la calidad y seguridad que merece. Aquí desglosamos cómo funciona, quién tiene el control y por qué cada pieza está en su lugar.
+
+---
+
+## 🚀 Funcionalidades Clave
+
+### 🖼️ Gestión de Contenido Visual para Propiedades
+
+La funcionalidad de imágenes es vital para presentar las propiedades de forma atractiva y profesional. Permite a los agentes y administradores subir, organizar y mantener las galerías de fotos de cada listado, mientras que los usuarios finales pueden explorar el contenido visual de forma fluida.
+
+**Historias de Usuario Clave en la Gestión de Imágenes:**
+
+* **Publicación de Propiedades con Impacto Visual:**
+    * Como un **Agente Inmobiliario**, puedo **subir múltiples imágenes** a una propiedad recién creada o existente. Esto me permite presentar visualmente mis propiedades de manera atractiva, captando la atención de posibles compradores o arrendatarios.
+* **Actualización y Mantenimiento de Galerías:**
+    * Como un **Agente Inmobiliario**, puedo **modificar o eliminar imágenes específicas** de mis propiedades. Esto es crucial para mantener actualizada la presentación visual de una propiedad, eliminando fotos obsoletas o subiendo nuevas que reflejen cambios.
+* **Exploración Visual para Usuarios Finales:**
+    * Como un **Usuario Final (Invitado o Registrado)**, puedo **visualizar todas las imágenes** asociadas a una propiedad. Esto me brinda una experiencia inmersiva y detallada, ayudándome a tomar decisiones informadas sobre la propiedad.
+
+### 🛡️ Seguridad Centralizada: Quién Accede y Por Qué
+
+La seguridad es primordial. Cada operación con imágenes está protegida por una serie de "guardias" que verifican tu identidad, tu rol y, de forma crucial, si tienes la **propiedad del recurso** que intentas modificar.
+
+---
+
+## 2. 🚦 `ImagesController`: Tu Comando de Fotos Digitales
+
+El `ImagesController` es el centro de mando para todas las interacciones HTTP con tus imágenes. Cada "puerta" (endpoint) está diseñada para una tarea específica y protegida con el nivel de seguridad adecuado.
+
+**Ruta Base**: `/images`
+
+---
+
+### 2.1. Puertas y Sus Vigilantes (Endpoints y Guardias)
+
+#### `POST /images` - ¡Añade tu Nueva Imagen! 📸
+
+* **Propósito**: Permite subir nuevas fotos al sistema, enlazándolas a una propiedad existente.
+* **Guardias**:
+    * **`AuthGuard`**: **(El Portero)** - ¿Tienes tu identificación? Verifica que estás **autenticado** (tienes un JWT válido). Sin él, acceso denegado (HTTP `401: No Autorizado`).
+    * **`RolesGuard`**: **(El Selector de Profesionales)** - ¿Eres quien dice ser y tienes el permiso? Asegura que solo **Agentes (`Role.User`)** o **Administradores (`Role.Admin`)** pueden subir imágenes. Otros roles, prohibidos (HTTP `403: Prohibido`).
+* **Acceso Permitido**: Agentes Inmobiliarios y Administradores autenticados.
+
+#### `GET /images` - Un Vistazo al Álbum Completo 🌍
+
+* **Propósito**: Obtiene una lista de todas las imágenes disponibles en la plataforma.
+* **Guardias**: ¡Ninguno! Esta puerta está abierta.
+* **Acceso Permitido**: **Público en general**. Cualquiera puede ver las imágenes, lo cual es esencial para mostrar tus propiedades a todos los visitantes.
+
+#### `GET /images/:id` - Detalles de una Foto Específica 🔍
+
+* **Propósito**: Recupera los detalles de una imagen específica por su ID.
+* **Guardias**: ¡Ninguno!
+* **Acceso Permitido**: **Público en general**. Los visitantes pueden examinar fotos individuales.
+
+#### `PATCH /images/:id` - ¡Edita esa Foto! ✏️
+
+* **Propósito**: Permite modificar la información (título, descripción, archivo) de una imagen existente.
+* **Guardias**:
+    * **`AuthGuard`**: **(El Portero)** - Identidad confirmada.
+    * **`RolesGuard`**: **(El Selector de Roles)** - ¿Eres **Agente** o **Administrador**? Confirmado.
+    * **`PropertyOwnershipGuard`**: **(EL GUARDIÁN DEL DUEÑO)** - ¡Este es tu defensor de propiedad! Después de los dos primeros cheques, este guardia es el que pregunta: **"¿Esta foto es realmente tuya (o de la propiedad de tu agencia)?"**
+        * **Administradores**: Tienen un pase VIP; pueden modificar cualquier imagen.
+        * **Agentes Inmobiliarios (`User`)**: Solo podrán editar imágenes que estén directamente vinculadas a **propiedades que pertenecen a TU propia agencia**. Esto evita que un agente altere imágenes de propiedades ajenas.
+* **Acceso Permitido**: Agentes Inmobiliarios (solo sobre sus propias imágenes) y Administradores.
+
+#### `DELETE /images/:id` - ¡Bye Bye Foto! 👋
+
+* **Propósito**: Permite eliminar una imagen específica del sistema.
+* **Guardias**:
+    * **`AuthGuard`**: **(El Portero)** - Autenticación obligatoria.
+    * **`RolesGuard`**: **(El Selector de Roles)** - Solo **Agentes** o **Administradores** tienen el permiso de rol.
+    * **`PropertyOwnershipGuard`**: **(EL MISMO GUARDIÁN DEL DUEÑO)** - Al igual que en `PATCH`, este guardia es crucial. Se asegura de que:
+        * Los **Administradores** pueden eliminar cualquier imagen.
+        * Los **Agentes Inmobiliarios (`User`)** solo pueden eliminar imágenes que estén asociadas a **propiedades de su propia agencia**.
+* **Acceso Permitido**: Agentes Inmobiliarios (solo sobre sus propias imágenes) y Administradores.
+
+---
+
+## 3. 🛡️ Los Guardias: Tus Escuderos de la Seguridad (Profundizando)
+
+Estos son los vigilantes que protegen tu API de imágenes, y cada uno tiene un papel irremplazable.
+
+---
+
+### 3.1. `AuthGuard`: El Bouncer Infalible
+
+* **Su Función Vital**: Es el primer control de seguridad. Su única misión es validar que el usuario que envía una solicitud ha iniciado sesión correctamente y ha proporcionado un **token JWT (JSON Web Token) válido**. Si el token está ausente o es incorrecto, la solicitud es rechazada inmediatamente con un error `401 Unauthorized`. Si es válido, extrae los datos clave del usuario (ID, roles) y los adjunta a la solicitud para que los siguientes guardias puedan usarlos.
+
+### 3.2. `RolesGuard`: El Clasificador de Privilegios
+
+* **Su Función Vital**: Se ejecuta *después* de `AuthGuard`. Una vez que la identidad del usuario está confirmada, `RolesGuard` verifica el **tipo de usuario** que eres. Lee los roles que tú (`@Roles(Role.User, Role.Admin)`) has especificado para un endpoint y compara esto con los roles que el usuario autenticado realmente tiene. Si no tienes el "rango" necesario, te detiene con un `403 Forbidden`.
+
+### 3.3. `PropertyOwnershipGuard` (¡El Guardia Recién Llegado y Esencial!)
+
+* **Su Función Vital**: Este es el **guardia especializado** y la pieza clave de nuestra seguridad avanzada en este módulo. Mientras que `AuthGuard` sabe *quién eres* y `RolesGuard` sabe *qué tipo de usuario eres*, `PropertyOwnershipGuard` va un paso más allá y pregunta: **"¿Tienes derecho a TOCAR este recurso específico (esta imagen)?"**
+* **¿Por qué fue indispensable crearlo?**: Los guardias genéricos como `AuthGuard` y `RolesGuard` son excelentes, pero no tienen el concepto de "pertenencia" de un recurso individual. Un `RolesGuard` sabe que un "Agente" puede editar, pero no distingue entre "las propiedades del Agente A" y "las propiedades del Agente B".
+    * Sin este guardia, cualquier Agente Inmobiliario autenticado (`Role.User`) podría haber actualizado o eliminado *cualquier imagen* en el sistema si conocía su ID. Esto habría sido un **fallo de seguridad crítico**, permitiendo que los agentes manipulen datos que no les pertenecen, lo que va totalmente en contra de la lógica de negocio de nuestra plataforma.
+* **Su Solución**: `PropertyOwnershipGuard` cierra esta brecha de seguridad de forma elegante y efectiva. Cuando una solicitud para `PATCH` o `DELETE` llega:
+    1.  Verifica si el usuario es un **Administrador**. Si lo es, permite el paso (los administradores tienen pase libre).
+    2.  Si no es administrador, toma el **ID de la imagen** de la URL.
+    3.  A través de nuestro `ImagesService`, rastrea la imagen hasta la **propiedad** a la que pertenece, luego a la **agencia** dueña de esa propiedad, y finalmente, al **usuario propietario** de esa agencia.
+    4.  Compara el ID del usuario que está haciendo la solicitud con el ID del usuario propietario de la agencia de la imagen.
+    5.  Si coinciden, ¡permite la acción! Si no, o si la cadena de propiedad no se puede establecer, lanza un error `403 Forbidden` (`No tienes permisos para realizar esta acción sobre esta imagen.`).
+
+---
+
+## 4. ⚙️ `ImagesModule`: La Orquesta de Dependencias
+
+El `ImagesModule` es el **director de orquesta** que organiza todos los componentes necesarios para que el módulo de imágenes funcione. Es donde NestJS aprende cómo construir cada pieza (servicios, controladores, guardias) y cómo suministrarles todo lo que necesitan mediante la **inyección de dependencias**. Quizás te preguntes por qué ves elementos como `User`, `Agency`, `JwtService`, `UserService`, etc., listados aquí si no los "utilizas directamente" en el código de tu `ImagesController` o `ImagesService` (que residen en esta misma carpeta). Aquí está la explicación detallada:
+
+---
+
+### 4.1. Por qué `TypeOrmModule.forFeature([Images, Property, User, Agency])` en `imports`
+
+Imagina que tu `ImagesService` es un investigador que necesita entender la historia completa de una imagen, incluyendo quién es su dueño. Para ello, debe seguir una **cadena de relaciones interconectadas** en la base de datos:
+
+1.  Comienza con la **Imagen** (`Images`).
+2.  La Imagen está vinculada a una **Propiedad** (`Property`).
+3.  La Propiedad, a su vez, está asociada a una **Agencia** (`Agency`).
+4.  Finalmente, la Agencia tiene un **Usuario** (`User`) que es su propietario principal.
+
+Para que **TypeORM** (nuestra herramienta ORM que mapea objetos a la base de datos) pueda seguir y cargar eficientemente toda esta cadena de relaciones (especialmente cuando tu `ImagesService` ejecuta `findOneWithPropertyAndOwner` para el `PropertyOwnershipGuard`), **necesita tener un "mapa completo" de todas estas entidades** (`Images`, `Property`, `User`, `Agency`). Al listarlas en `TypeOrmModule.forFeature()`, le estás indicando a NestJS: "Dentro de este `ImagesModule`, TypeORM tiene la información y la capacidad para trabajar con los datos de estas cuatro entidades y sus relaciones, incluso si no voy a inyectar directamente `Repository<User>` o `Repository<Agency>` aquí." Es como darle al investigador un mapa completo de la ciudad, aunque solo le pidas que se enfoque en una calle específica para su caso.
+
+### 4.2. Por qué `JwtService`, `UserService`, `AgencyService`, `AuthGuard`, `RolesGuard` en `providers`
+
+Esta es la esencia de la **inyección de dependencias** en NestJS. Piensa en tu `ImagesModule` como una **línea de ensamblaje en una fábrica**. Para ensamblar las "partes" que se van a utilizar en este módulo (como tu `ImagesController`), esa línea de ensamblaje necesita tener a mano todos los "componentes" y las "herramientas" necesarias.
+
+1.  **Tu `ImagesController` utiliza `AuthGuard`, `RolesGuard` y `PropertyOwnershipGuard`**: Cuando decoras un endpoint del controlador con `@UseGuards(AuthGuard, RolesGuard, PropertyOwnershipGuard)`, le estás diciendo a NestJS: "Antes de ejecutar la lógica de este endpoint, por favor, construye y ejecuta estas tres 'piezas de seguridad' en este orden."
+
+2.  **`AuthGuard` tiene sus propias dependencias (¡sus propias "herramientas" internas!)**: Aquí reside la clave de la confusión inicial. Si observamos el constructor de tu `AuthGuard` (el archivo `auth.guard.ts`), notarás que explícitamente solicita tres "herramientas" para poder operar:
+    * **`JwtService`**: La herramienta especializada en verificar y manipular los tokens JWT de autenticación.
+    * **`UserService`**: La herramienta para interactuar con los datos de los usuarios (por ejemplo, para buscar un usuario por su ID y obtener sus roles).
+    * **`AgencyService`**: La herramienta para interactuar con los datos de las agencias (por ejemplo, para buscar una agencia).
+
+    Para que NestJS pueda "construir" la instancia de `AuthGuard` y luego pasársela a tu `ImagesController`, primero tiene que asegurarse de que esas tres "herramientas" (`JwtService`, `UserService`, `AgencyService`) estén disponibles para `AuthGuard`.
+
+3.  **El `ImagesModule` debe "proveer" esas dependencias para que estén disponibles**:
+    * Al incluir `JwtService`, `UserService`, `AgencyService`, `AuthGuard` y `RolesGuard` en el array `providers` de tu `ImagesModule`, le estás indicando a NestJS: "Escucha, si cualquier parte de este módulo (como el `ImagesController` o cualquiera de sus guardias) necesita una instancia de `JwtService`, `UserService`, `AgencyService`, `AuthGuard` o `RolesGuard`, **yo sé cómo crearlas y las pongo a tu disposición aquí mismo**."
+    * Es como si tu `ImagesModule` dijera: "Además de mis propias herramientas para manejar imágenes, he 'importado' o tengo 'prestadas' las herramientas de verificación de tokens (`JwtService`), y las listas de usuarios y agencias (`UserService`, `AgencyService`) para poder ensamblar y ejecutar los guardias de seguridad que mis endpoints necesitan."
+
+En resumen, aunque el código que escribes directamente en `ImagesController` o `ImagesService` dentro de la carpeta `images` no "llame" explícitamente a `UserService` o `JwtService`, los **guardias que sí utiliza el `ImagesController` los requieren como sus propias dependencias internas**. El `ImagesModule` actúa como un orquestador inteligente que garantiza que todas las piezas estén disponibles y correctamente interconectadas, permitiendo que tu sistema de seguridad y tus operaciones de imágenes funcionen de forma impecable.

--- a/src/modules/images/images.controller.ts
+++ b/src/modules/images/images.controller.ts
@@ -62,7 +62,6 @@ export class ImagesController {
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @UseGuards(AuthGuard, RolesGuard)
-  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Eliminar una imagen por ID (Agente o Admin dueño)' })
   @ApiResponse({ status: 204, description: 'Imagen eliminada exitosamente.' })
   @ApiResponse({ status: 401, description: 'No autorizado.' })

--- a/src/modules/images/images.controller.ts
+++ b/src/modules/images/images.controller.ts
@@ -1,29 +1,54 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, ParseUUIDPipe, HttpCode, HttpStatus, BadRequestException } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, ParseUUIDPipe, HttpCode, HttpStatus, BadRequestException, UseGuards } from '@nestjs/common';
 import { ImagesService } from './images.service';
 import { CreateImageDto } from './create-image.dto';
 import { UpdateImageDto } from './update-image.dto';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from 'src/guard/auth.guard';
+import { RolesGuard } from 'src/guard/roles.guard';
+import { Roles } from 'src/decorators/role.decorator';
+import { Role } from 'src/Enum/roles.enum';
 
+@ApiTags('images')
+@ApiBearerAuth()
 @Controller('images')
 export class ImagesController {
   constructor(private readonly imagesService: ImagesService) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(Role.User, Role.Admin)
+  @ApiOperation({ summary: 'Subir una nueva imagen (Agente o Admin)' })
+  @ApiResponse({ status: 201, description: 'Imagen creada exitosamente.' })
+  @ApiResponse({ status: 401, description: 'No autorizado.' })
+  @ApiResponse({ status: 403, description: 'Prohibido (rol incorrecto).' })
   async create(@Body() createImageDto: CreateImageDto) {
     return this.imagesService.create(createImageDto);
   }
 
   @Get()
+  @ApiOperation({ summary: 'Obtener todas las imágenes (Público)' })
+  @ApiResponse({ status: 200, description: 'Listado de todas las imágenes.' })
   async findAll() {
     return this.imagesService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Obtener una imagen por ID (Público)' })
+  @ApiResponse({ status: 200, description: 'Detalle de una imagen.' })
+  @ApiResponse({ status: 404, description: 'Imagen no encontrada.' })
   async findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.imagesService.findOne(id);
   }
 
   @Patch(':id')
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(Role.User, Role.Admin)
+  @ApiOperation({ summary: 'Actualizar una imagen por ID (Agente o Admin dueño)' })
+  @ApiResponse({ status: 200, description: 'Imagen actualizada exitosamente.' })
+  @ApiResponse({ status: 400, description: 'Solicitud inválida.' })
+  @ApiResponse({ status: 401, description: 'No autorizado.' })
+  @ApiResponse({ status: 403, description: 'Prohibido (rol o no es dueño).' })
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateImageDto: UpdateImageDto,
@@ -36,6 +61,13 @@ export class ImagesController {
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @UseGuards(AuthGuard, RolesGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Eliminar una imagen por ID (Agente o Admin dueño)' })
+  @ApiResponse({ status: 204, description: 'Imagen eliminada exitosamente.' })
+  @ApiResponse({ status: 401, description: 'No autorizado.' })
+  @ApiResponse({ status: 403, description: 'Prohibido (rol o no es dueño).' })
+  @ApiResponse({ status: 404, description: 'Imagen no encontrada.' })
   async remove(@Param('id', ParseUUIDPipe) id: string) {
     await this.imagesService.remove(id);
   }

--- a/src/modules/images/images.module.ts
+++ b/src/modules/images/images.module.ts
@@ -4,12 +4,20 @@ import { ImagesController } from './images.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Images } from './image.entity';
 import { Property } from '../property/property.entity';
+import { Agency } from '../agency/agency.entity';
+import { User } from '../user/user.entity';
+import { PropertyOwnershipGuard } from 'src/guard/property-ownership.guard';
+import { AuthGuard } from 'src/guard/auth.guard';
+import { RolesGuard } from 'src/guard/roles.guard';
+import { JwtService } from '@nestjs/jwt';
+import { UserService } from '../user/user.service';
+import { AgencyService } from '../agency/agency.service';
 
 
 @Module({
-  imports:[TypeOrmModule.forFeature([Images, Property])],
+  imports:[TypeOrmModule.forFeature([Images, Property, Agency, User])],
   controllers: [ImagesController],
-  providers: [ImagesService],
+  providers: [ImagesService, PropertyOwnershipGuard, AuthGuard, RolesGuard, JwtService, UserService, AgencyService],
   exports: [TypeOrmModule, ImagesService]
 })
 export class ImagesModule {}

--- a/src/modules/images/images.service.ts
+++ b/src/modules/images/images.service.ts
@@ -86,4 +86,15 @@ export class ImagesService {
     }
     await this.imagesRepository.softRemove(imageToRemove);
     }
+
+    async findOneWithPropertyAndOwner(id: string): Promise<Images | null> {
+    return await this.imagesRepository.findOne({
+      where: { id },
+      relations: [
+        'property',
+        'property.agency',
+        'property.agency.user'
+      ],
+    });
+  }
 }


### PR DESCRIPTION
Implementación de PropertyOwnershipGuard y ajuste en ImagesController
Este commit introduce una mejora significativa en la seguridad y el control de acceso de las imágenes en la plataforma.

Cambios realizados:
Creación del nuevo guardia PropertyOwnershipGuard: Este guardia especializado asegura que los usuarios (agentes) solo puedan modificar o eliminar imágenes que pertenezcan a propiedades de su propia agencia. Los administradores mantienen acceso total. Esto previene manipulaciones no autorizadas de recursos entre agencias.
Actualización del ImagesController: Los endpoints PATCH /images/:id y DELETE /images/:id ahora utilizan el PropertyOwnershipGuard además de los guardias de autenticación (AuthGuard) y roles (RolesGuard).
Ajustes en ImagesModule: Se actualizó la configuración del módulo para proveer el nuevo guardia y sus dependencias necesarias (User, Agency) y así asegurar la correcta inyección de dependencias.
Esta implementación refuerza la seguridad y la integridad de los datos, garantizando que cada agente tenga control exclusivo sobre los recursos de su agencia.