### PR TITLE
Implementar seguridad de acceso por propiedad de agencia y roles

### DIFF
--- a/src/guard/agencyOwnership.guard.ts
+++ b/src/guard/agencyOwnership.guard.ts
@@ -1,0 +1,44 @@
+import { CanActivate, ExecutionContext, Injectable, ForbiddenException, UnauthorizedException, BadRequestException, NotFoundException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { Role } from '../Enum/roles.enum';
+import { AgencyService } from 'src/modules/agency/agency.service';
+import { User } from 'src/modules/user/user.entity';
+
+@Injectable()
+export class AgencyOwnershipGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly agencyService: AgencyService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const userPayload = request.user;
+
+    if (!userPayload) {
+      throw new UnauthorizedException('Usuario no autenticado.');
+    }
+
+    if (userPayload.roles && userPayload.roles.includes(Role.Admin)) {
+      return true;
+    }
+
+    const agencyId = request.params.agencyId;
+    if (!agencyId) {
+      throw new BadRequestException('ID de agencia no proporcionado en la ruta.');
+    }
+
+    const agency = await this.agencyService.findOne(agencyId);
+
+    if (!agency || !agency.user) {
+      throw new ForbiddenException('Acceso denegado: Agencia o propietario no encontrado.');
+    }
+
+    if (agency.user.id === userPayload.id) {
+      return true;
+    }
+
+    throw new ForbiddenException('No tienes permisos para realizar esta acción sobre esta agencia.');
+  }
+}

--- a/src/modules/customization/Readme.md
+++ b/src/modules/customization/Readme.md
@@ -1,6 +1,8 @@
-# Customization
+# Módulo de Personalización (Customization)
 
-...
+Este módulo se encarga de gestionar la identidad visual y el branding de las agencias en el sistema, permitiendo configurar colores y logos.
+
+---
 
 ## 🚀 Funcionalidades Clave
 
@@ -11,18 +13,43 @@ La funcionalidad de Customization permite a cada agencia que utiliza la platafor
 **Historias de Usuario Agente en Customization:**
 
 * **Configuración Inicial de Branding:**
-    * Como un **Agente (Utilizando Customization)**, puedo **asignar los colores y el logo de la marca** a una nueva agencia. Esto permite que cada agencia tenga una identidad visual única desde el momento en que se integra a la plataforma. El sistema utiliza los `mainColors`, `navbarColor`, `buttonColor`, `backgroundColor`, `secondaryColor` definidos, así como el `logoImage` y el `banner` proporcionados.
+    * Como un **Agente (Utilizando Customization)**, puedo **asignar los colores y el logo de la marca** a una agencia. Esto permite que cada agencia tenga una identidad visual única desde el momento en que se integra a la plataforma. El sistema utiliza los `mainColors`, `navbarColor`, `buttonColor`, `backgroundColor`, `secondaryColor` definidos, así como el `logoImage` y el `banner` proporcionados. **Solo el agente propietario de la agencia o un administrador pueden realizar esta acción.**
 
 * **Actualización de la Identidad Visual:**
-    * Como un **Agente (Utilizando Customization)**, puedo **modificar la configuración de personalización de la agencia**. Esto es crucial para actualizar el logo, los colores o la información de contacto cuando la marca de la agencia evoluciona, asegurando que la plataforma siempre refleje la identidad más actual.
+    * Como un **Agente (Utilizando Customization)**, puedo **modificar la configuración de personalización de la agencia**. Esto es crucial para actualizar el logo, los colores o la información de contacto cuando la marca de la agencia evoluciona, asegurando que la plataforma siempre refleje la identidad más actual. **Solo el agente propietario de la agencia o un administrador pueden realizar esta acción.**
 
 * **Experiencia de Usuario Personalizada:**
     * Como un **Usuario Final** que interactúa con una agencia específica, experimentaré una **interfaz de usuario que refleje la marca de esa agencia**. Esto crea una experiencia más cohesiva, profesional y personalizada, donde cada agencia se siente como un entorno propio dentro de la plataforma.
 
 **Endpoints Principales:**
 
-* `POST /agencies/:agencyId/customization`: Crea la configuración de personalización para una agencia.
-* `GET /agencies/:agencyId/customization`: Recupera la configuración de personalización de una agencia.
-* `PATCH /agencies/:agencyId/customization`: Actualiza la configuración de personalización de una agencia.
+* `POST /agencies/:agencyId/customization`: Crea la configuración de personalización para una agencia. **Protegido por `AuthGuard`, `RolesGuard` y `AgencyOwnershipGuard`.**
+* `GET /agencies/:agencyId/customization`: Recupera la configuración de personalización de una agencia. **Este endpoint es de acceso público.**
+* `PATCH /agencies/:agencyId/customization`: Actualiza la configuración de personalización de una agencia. **Protegido por `AuthGuard`, `RolesGuard` y `AgencyOwnershipGuard`.**
 
-...
+---
+
+## 🛡️ Guardias de Seguridad Implementados
+
+Para garantizar la seguridad y el control de acceso a las funcionalidades de personalización, se utilizan los siguientes guardias de NestJS:
+
+### `AuthGuard`
+
+* **Propósito**: Este guardia asegura que solo los usuarios **autenticados** puedan interactuar con las rutas que requieren identificación.
+* **Funcionamiento**: Valida el token JWT presente en las cookies de la solicitud. Si
+
+### `RolesGuard`
+
+* **Propósito**: Después de la autenticación, este guardia verifica que el usuario autenticado posea los **roles necesarios** para acceder a una ruta específica. Trabaja en conjunto con el decorador `@Roles()` definido en los controladores.
+* **Funcionamiento**: Lee los roles permitidos para la ruta desde los metadatos de la ruta y los compara con los roles del usuario obtenidos de `request.user`. Si el usuario no tiene al menos uno de los roles autorizados, la solicitud es denegada con un error `403 Forbidden`.
+* **Aplicación**: Utilizado en los endpoints `POST` y `PATCH` de `customization`, requiriendo los roles `User` (para agentes) o `Admin`.
+
+### `AgencyOwnershipGuard`
+
+* **Propósito**: Este es un guardia de **autorización granular** que garantiza que un agente solo pueda modificar o crear la personalización para **su propia agencia**. Un administrador, sin embargo, tiene acceso total a la personalización de cualquier agencia.
+* **Funcionamiento**:
+    1.  Primero, verifica si el usuario autenticado tiene el rol `Admin`. Si es así, se le otorga acceso inmediatamente (un administrador puede gestionar la personalización de cualquier agencia).
+    2.  Si el usuario no es `Admin`, obtiene el `agencyId` de los parámetros de la URL de la solicitud.
+    3.  Luego, utiliza el `AgencyService` (específicamente, el método `findOne`) para recuperar los detalles de la agencia, asegurándose de que la relación con su `user` (el propietario) esté cargada.
+    4.  Finalmente, compara el `id` del usuario autenticado (`request.user.id`) con el `id` del propietario de la agencia (`agency.user.id`). Si coinciden, el acceso es permitido; de lo contrario, la solicitud es rechazada con un error `403 Forbidden`.
+* **Aplicación**: Esencial para proteger los endpoints `POST` y `PATCH` de `customization`, asegurando que los agentes solo puedan configurar o actualizar la marca de sus propias agencias.

--- a/src/modules/customization/customization.controller.ts
+++ b/src/modules/customization/customization.controller.ts
@@ -1,13 +1,25 @@
-import {Controller, Get, Post, Body, Patch, Param} from '@nestjs/common';
+import {Controller, Get, Post, Body, Patch, Param, UseGuards} from '@nestjs/common';
 import { CustomizationService } from './customization.service';
 import { UpdateCustomizationDto } from './update-customization.dto';
 import { CreateCustomizationDto } from './create-customization.dto';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Roles } from 'src/decorators/role.decorator';
+import { Role } from 'src/Enum/roles.enum';
+import { AuthGuard } from 'src/guard/auth.guard';
+import { RolesGuard } from 'src/guard/roles.guard';
+import { AgencyOwnershipGuard } from 'src/guard/agencyOwnership.guard';
 
+@ApiTags('Customization')
+@ApiBearerAuth()
 @Controller('agencies/:agencyId/customization')
 export class CustomizationController {
   constructor(private readonly customizationService: CustomizationService) {}
 
+
   @Post()
+  @UseGuards(AuthGuard, RolesGuard, AgencyOwnershipGuard)
+  @Roles(Role.User, Role.Admin)
+  @ApiOperation({ summary: 'Crea la configuración de personalización (branding) para una agencia.' })
   async create(
     @Param('agencyId') agencyId: string,
     @Body() createCustomizationDto: CreateCustomizationDto) 
@@ -16,6 +28,7 @@ export class CustomizationController {
   }
 
   @Get()
+  @ApiOperation({ summary: 'Recupera la configuración de personalización de una agencia específica.' })
   async findOneByAgencyId(
     @Param('agencyId') agencyId: string)
     {
@@ -23,6 +36,9 @@ export class CustomizationController {
   }
 
   @Patch()
+  @UseGuards(AuthGuard, RolesGuard, AgencyOwnershipGuard)
+  @Roles(Role.User, Role.Admin)
+  @ApiOperation({ summary: 'Actualiza la configuración de personalización (branding) de una agencia.' })
   async update(
     @Param('agencyId') agencyId: string,
     @Body() updateCustomizationDto: UpdateCustomizationDto,) {

--- a/src/modules/customization/customization.module.ts
+++ b/src/modules/customization/customization.module.ts
@@ -4,12 +4,18 @@ import { CustomizationController } from './customization.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Customization } from './customization.entity';
 import { Agency } from 'src/modules/agency/agency.entity';
+import { AgencyOwnershipGuard } from 'src/guard/agencyOwnership.guard';
+import { AgencyService } from '../agency/agency.service';
+import { UserService } from '../user/user.service';
+import { JwtService } from '@nestjs/jwt';
+import { AuthGuard } from 'src/guard/auth.guard';
+import { RolesGuard } from 'src/guard/roles.guard';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Customization, Agency])
 ],
   controllers: [CustomizationController],
-  providers: [CustomizationService],
+  providers: [CustomizationService, AgencyOwnershipGuard, AgencyService, UserService, JwtService, AuthGuard, RolesGuard],
   exports: [CustomizationService, TypeOrmModule],
 })
 export class CustomizationModule {}


### PR DESCRIPTION
Este commit introduce mejoras significativas en la seguridad del módulo de personalización (customization) para asegurar que solo usuarios autorizados puedan configurar y actualizar el branding de las agencias.

Cambios principales:

- **Se añadió `AgencyOwnershipGuard`:**
    - Este nuevo guardia garantiza que solo el propietario de una agencia o un administrador del sistema puedan crear o modificar su personalización.
    - Utiliza el método `AgencyService.findOne` para obtener la agencia y verificar su propietario, comparándolo con el usuario autenticado (`request.user.id`).
- **Actualización de Endpoints de Customization:**
    - Los endpoints `POST /agencies/:agencyId/customization` y `PATCH /agencies/:agencyId/customization` ahora están protegidos por una cadena de guardias: `AuthGuard`, `RolesGuard` y el nuevo `AgencyOwnershipGuard`.
    - Esto asegura una doble verificación de seguridad: autenticación, roles (`User` o `Admin`) y, crucialmente, la propiedad de la agencia.
- **`AgencyService` no modificado (se usa `findOne` existente):**
    - Se confirmó que el método `AgencyService.findOne` ya carga la relación `user` (propietario de la agencia), lo que permite al `AgencyOwnershipGuard` funcionar correctamente sin necesidad de un nuevo método dedicado.
- **Documentación actualizada (`README.md`):**
    - Se actualizó el `README.md` para reflejar las nuevas funcionalidades, la descripción de los endpoints de personalización y, de manera detallada, el propósito y funcionamiento de cada guardia de seguridad (`AuthGuard`, `RolesGuard`, `AgencyOwnershipGuard`).

Este cambio refuerza la seguridad y el control de acceso, previniendo que usuarios no autorizados manipulen la personalización de agencias ajenas.